### PR TITLE
Add link to web IRC to reduce friction for new users

### DIFF
--- a/getinvolved.md
+++ b/getinvolved.md
@@ -6,7 +6,7 @@ layout: default
 
 Want to contribute to the project? We suggest joining the developer chat, which may be accessed via your choice of IRC or Discord (both channels are bridged so you can talk to everyone from either protocol).
 
-* IRC: \#scopehal on [irc.libera.chat](ircs://irc.libera.chat:6697/scopehal)
+* IRC webchat: [\#scopehal on Libera.Chat](https://web.libera.chat/#scopehal) (or [connect with your own client](ircs://irc.libera.chat:6697/scopehal))
 * Discord: [\#scopehal on 1bitsquared](https://discord.gg/URuN2BuGwG)
 
 This is the primary mechanism for active developers to discuss features they're working on, help each other out, and coordinate the overall direction of the project.


### PR DESCRIPTION
Users seeking assistance may not know how to use IRC but also might not want to have to sign up for Discord just to ask a question. To fix this, add a link to the channel in Libera's webchat so users can start chatting in just two clicks. Users familiar with IRC can use the `ircs://` link titled "connect with your own client" to connect with their own IRC client.

I'm releasing these changes under the [Creative Commons Zero Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/), so feel free to relicense them however you see fit.